### PR TITLE
chore(ci): modernize linter workflow defaults

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -48,8 +48,8 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
-          DEFAULT_BRANCH: master
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` in lint workflow from `v2` to `v4`
- upgrade `github/super-linter` from `v4` to `v7`
- replace hardcoded `DEFAULT_BRANCH: master` with `${{ github.event.repository.default_branch }}`

## Why
This keeps the lint workflow aligned with current maintained action majors and removes a brittle hardcoded default-branch value.

## Testing
- `python3` YAML parse check for `.github/workflows/linter.yml` (`yaml.safe_load`) ✅
- `actionlint` unavailable locally in this environment
